### PR TITLE
FEATURE: Make dependency to oauth2_proxy conditional

### DIFF
--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -2,4 +2,4 @@
 dependencies:
   - role: nginx
   - role: oauth2_proxy
-    when: mailhog.oauth2.proxy
+    when: mailhog.oauth2_proxy

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -2,3 +2,4 @@
 dependencies:
   - role: nginx
   - role: oauth2_proxy
+    when: mailhog.oauth2.proxy


### PR DESCRIPTION
Reason: the dependency brakes execution in projects where no oauth2 server is available